### PR TITLE
Patch to fix error in which the auth part of state was no longer recognized

### DIFF
--- a/client/Routes.js
+++ b/client/Routes.js
@@ -11,7 +11,7 @@ import CreateMemeForm from './components/forms/CreateMemeForm';
 import UnlistedMemes from './components/UnlistedMemes';
 import AllUser from './components/AllUsers';
 import SingleUser from './components/SingleUser';
-import { me } from './store';
+import { me } from './store/authReducer';
 import Order from './components/Order';
 
 /**

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { logout } from '../store';
-import { me } from '../store';
+import { me, logout } from '../store/authReducer';
 const Navbar = () => {
   const isLoggedIn = useSelector((state) => !!state.auth.id);
   const isLogged = useSelector((state) => state.auth);

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -10,7 +10,7 @@ import userReducer from './userReducer';
 import singleUserReducer from './singleUserReducer';
 
 const reducer = combineReducers({
-  authReducer,
+  auth: authReducer,
   memes: memesReducer,
   singleMeme: singleMemeReducer,
   OrderItems: OrderItemsReducer,


### PR DESCRIPTION
Gave authReducer the alias auth in the reducer combiner in the redux store. This fixes the bug that was causing useSelector to throw an error in the Routes and NavBar components.