### PR TITLE
remove delete meme route

### DIFF
--- a/server/api/memes.js
+++ b/server/api/memes.js
@@ -37,24 +37,6 @@ router.get('/:id', requireToken, isAdmin, async (req, res, next) => {
   }
 });
 
-router.delete('/:id', requireToken, isAdmin, async (req, res, next) => {
-  try {
-    const memeId = req.params.id;
-    const data = await Meme.destroy({
-      where: {
-        id: memeId,
-      },
-    });
-    if (data) {
-      res.sendStatus(204);
-    } else {
-      res.sendStatus(404);
-    }
-  } catch (error) {
-    next(error);
-  }
-});
-
 //validate if price is valid currency value
 router.put(
   '/:id',


### PR DESCRIPTION
Users/admins should not be able to delete memes as they are essential to archived orders
Route that allowed deletion of memes is removed